### PR TITLE
App icon enhancements to config

### DIFF
--- a/cmus-osx/notify.py
+++ b/cmus-osx/notify.py
@@ -25,7 +25,6 @@ sys.excepthook = exception_hook
 from meh import Config
 from meh import Option
 from meh import ExceptionInConfigError
-from os import path
 
 CONFIG_PATH = None
 
@@ -50,11 +49,9 @@ config += Option(
     "1: Keep old notifications around; "
     "2: Clear old notifications",
 )
-
 config += Option(
     "app_icon",
     dirname(CONFIG_PATH) + "/cmus-icon.png",
-    validator=isfile,
     comment="Fallback icon if no album artwork is avaliable",
 )
 config += Option(
@@ -74,6 +71,12 @@ except (IOError, ExceptionInConfigError):
 
 if config.display_mode == 0:
     exit(0)
+
+if config.app_icon:
+    # expand the path in memory to avoid writing absolute paths to config file
+    config._values["app_icon"] = expanduser(config.app_icon)
+    if not isfile(config._values["app_icon"]):
+        raise FileNotFoundError("invalid value for option 'app_icon'")
 
 # Quickly exit if paused
 if "status" in status:

--- a/cmus-osx/notify.py
+++ b/cmus-osx/notify.py
@@ -7,6 +7,7 @@ status = dict(zip(status_raw[0::2], status_raw[1::2]))
 from os.path import isdir
 from os.path import expanduser
 from os.path import isfile
+from os.path import dirname
 
 from logging import basicConfig
 from logging import error
@@ -24,6 +25,7 @@ sys.excepthook = exception_hook
 from meh import Config
 from meh import Option
 from meh import ExceptionInConfigError
+from os import path
 
 CONFIG_PATH = None
 
@@ -48,9 +50,10 @@ config += Option(
     "1: Keep old notifications around; "
     "2: Clear old notifications",
 )
+
 config += Option(
     "app_icon",
-    expanduser("~/.config/cmus/cmus-osx/cmus-icon.png"),
+    dirname(CONFIG_PATH) + "/cmus-icon.png",
     validator=isfile,
     comment="Fallback icon if no album artwork is avaliable",
 )
@@ -68,7 +71,6 @@ try:
 except (IOError, ExceptionInConfigError):
     config.dump(CONFIG_PATH)
     config = config.load(CONFIG_PATH)
-
 
 if config.display_mode == 0:
     exit(0)


### PR DESCRIPTION
* Assume `cmus-icon.png` location from the config file

* Expand home user constructions for the `app_icon` in the config. This is useful so there is no absolute paths 😄 
Didn't use the validator, because there is no way to modify the value before it is called.