### PR TITLE
notifications: search for albumartist when artist is not present

### DIFF
--- a/cmus-osx/notify.py
+++ b/cmus-osx/notify.py
@@ -128,6 +128,8 @@ if "title" in status:
 
 if "artist" in status:
     message += status["artist"]
+elif "albumartist" in status:
+    message += status["albumartist"]
 
 if "album" in status:
     message += " – %s" % status["album"]


### PR DESCRIPTION
This fixes an issue when artist is not present. For ex, flac files tend to use `albumartist` in the tags.