### PR TITLE
Setup: Add self-upgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ It adds notification and media key support on par with other media players such 
 macOS automatically launches iTunes once a media key is pressed.
 Installing [noTunes](https://github.com/tombonez/noTunes) is the recommended solution to prevent this from happening.
 
-Requires [PIP](https://pip.pypa.io/en/stable/installing/).
+Requires [PIP](https://pip.pypa.io/en/stable/installing/) installed.
 
 ```bash
 git clone https://github.com/PhilipTrauner/cmus-osx.git
@@ -32,6 +32,13 @@ export PYTHON_CONFIGURE_OPTS="--enable-framework"
 
 ### Configuration
 A config file is created on first usage: `~/.config/cmus/cmus-osx/cmus-osx.config`
+
+### Upgrade
+
+```bash
+cd `~/.cmus/cmus-osx` (or where you have it installed)
+./setup.py upgrade
+```
 
 ### Credits
 * [azadkuh](https://github.com/azadkuh): all versions up to and including v1.2.0

--- a/README.md
+++ b/README.md
@@ -6,30 +6,29 @@
 ![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)
 [![](https://travis-ci.org/PhilipTrauner/cmus-osx.svg?branch=master)](https://travis-ci.org/PhilipTrauner/cmus-osx)
 
-**cmus-osx** tightly integrates [*cmus*](https://cmus.github.io/) into *macOS*.  
+**cmus-osx** tightly integrates [*cmus*](https://cmus.github.io/) into *macOS*.
 It adds notification and media key support on par with other media players such as iTunes.
 
 ### Installation
-macOS automatically launches iTunes once a media key is pressed.  
+macOS automatically launches iTunes once a media key is pressed.
 Installing [noTunes](https://github.com/tombonez/noTunes) is the recommended solution to prevent this from happening.
+
+Requires [PIP](https://pip.pypa.io/en/stable/installing/).
 
 ```bash
 git clone https://github.com/PhilipTrauner/cmus-osx.git
 cd cmus-osx
-pip3 install -r requirements.txt
 ./setup.py install
 ```
 
 Uninstall **cmus-osx**: `./setup.py uninstall`
 
 #### pyenv
-Framework building has to be enabled, otherwise notifications cannot be created.  
+Framework building has to be enabled, otherwise notifications cannot be created.
 Add this export to your shell-rc and rebuild.
 ```bash
 export PYTHON_CONFIGURE_OPTS="--enable-framework"
 ```
-
-
 
 ### Configuration
 A config file is created on first usage: `~/.config/cmus/cmus-osx/cmus-osx.config`

--- a/setup.py
+++ b/setup.py
@@ -1,35 +1,35 @@
 #!/usr/bin/env python3
+import argparse
+from os import chdir
+from os import environ
+from os import listdir
 from os.path import expanduser
 from os.path import isdir
 from os.path import isfile
+from shutil import copy
 from shutil import copytree
 from shutil import rmtree
 from subprocess import call
+from subprocess import check_call
 from sys import argv
 from sys import executable
-from subprocess import check_output
-from os import environ
+from tempfile import mkdtemp
 
+REPO = "https://github.com/PhilipTrauner/cmus-osx.git"
+BRANCH = "master"
 FOLDER_NAME = "cmus-osx/"
+COPY_FILES = ["requirements.txt", "setup.py"]
 MISSING_DEP_HELP = "Consult the installation section in README."
 
-if environ.get('ENV') is None:
+if environ.get("ENV") is None:
     REQUIREMENTS_FILE = "requirements.txt"
-elif environ.get('ENV') == "dev":
+elif environ.get("ENV") == "dev":
     REQUIREMENTS_FILE = "requirements-dev.txt"
 
 CMUS_BASE_DIR = None
-
 for cmus_base_dir in [expanduser("~/.config/cmus/"), expanduser("~/.cmus/")]:
     if isdir(cmus_base_dir):
         CMUS_BASE_DIR = cmus_base_dir
-
-if CMUS_BASE_DIR is None:
-    print("cmus config directory not found, aborting...")
-    exit(1)
-else:
-    print("cmus config directory: '%s'" % CMUS_BASE_DIR)
-
 
 RC_PATH = CMUS_BASE_DIR + "rc"
 MEDIA_KEYS_PATH = CMUS_BASE_DIR + FOLDER_NAME + "media-keys.py"
@@ -37,23 +37,50 @@ RC_ENTRY = "shell %s &\n" % MEDIA_KEYS_PATH
 NOTIFY_PATH = CMUS_BASE_DIR + FOLDER_NAME + "notify.py"
 AUTOSAVE_ENTRY = "set status_display_program=%s" % NOTIFY_PATH
 
+
+def print_header():
+    if CMUS_BASE_DIR is None:
+        print("cmus config directory not found, aborting...")
+        exit(1)
+    else:
+        print("cmus config directory: '%s'" % CMUS_BASE_DIR)
+
+
 def process_reqs(action):
+    pip_args = []
+    if args.quiet is True:
+        pip_args += ["-q"]
+
     if action == "install":
         print("Installing requirements...")
-
-        call([executable, '-m', 'pip', 'install', '-r', REQUIREMENTS_FILE])
+        check_call(
+            [executable, "-m", "pip", "install", "-r", REQUIREMENTS_FILE] + pip_args
+        )
     elif action == "uninstall":
         print("Uninstalling requirements...")
-        call([executable, '-m', 'pip', 'uninstall', '-r', REQUIREMENTS_FILE])
+        check_call(
+            [executable, "-m", "pip", "uninstall", "-r", REQUIREMENTS_FILE] + pip_args
+        )
 
 
 def install():
+    print_header()
     process_reqs(argv[1])
 
     if isdir(CMUS_BASE_DIR):
         if isdir(CMUS_BASE_DIR + FOLDER_NAME):
-            rmtree(CMUS_BASE_DIR + FOLDER_NAME)
-        copytree(FOLDER_NAME, CMUS_BASE_DIR + FOLDER_NAME)
+            if args.no_replace is False:
+                rmtree(CMUS_BASE_DIR + FOLDER_NAME)
+                copytree(FOLDER_NAME, CMUS_BASE_DIR + FOLDER_NAME)
+            else:
+                src_files = listdir(FOLDER_NAME)
+                for file in src_files:
+                    copy(FOLDER_NAME + file, CMUS_BASE_DIR + FOLDER_NAME)
+                rmtree(CMUS_BASE_DIR + FOLDER_NAME + "__pycache__", ignore_errors=True)
+
+            for file in COPY_FILES:
+                copy(file, CMUS_BASE_DIR + FOLDER_NAME + file)
+
     if isfile(RC_PATH):
         if RC_ENTRY not in open(RC_PATH, "r").read():
             open(RC_PATH, "a").write(RC_ENTRY)
@@ -78,10 +105,15 @@ def install():
     if pyobjc_installed:
         call([NOTIFY_PATH, "title", "Install successful!"])
 
-    print("\nInstalled. To enable notifications execute:\n%s\nin cmus." % AUTOSAVE_ENTRY)
+    if args.no_replace is False:
+        print(
+            "\nInstalled. To enable notifications execute:\n%s\nin cmus."
+            % AUTOSAVE_ENTRY
+        )
 
 
 def uninstall():
+    print_header()
     process_reqs(argv[1])
 
     if isdir(CMUS_BASE_DIR + FOLDER_NAME):
@@ -96,9 +128,35 @@ def uninstall():
                 rc.write(line + "\n")
 
 
-COMMANDS = {"install": install, "uninstall": uninstall}
+def upgrade():
+    tmpdir = mkdtemp()
 
-if len(argv) != 2:
-    print("No action specified. (avaliable: %s)" % ", ".join(COMMANDS.keys()))
-elif argv[1] in COMMANDS:
-    COMMANDS[argv[1]]()
+    try:
+        check_call(["git", "clone", "-b", BRANCH, REPO, tmpdir])
+        print()
+        chdir(tmpdir)
+        check_call(["./setup.py", "install", "-q", "--no-replace"])
+        print("Upgraded sucessfully")
+    finally:
+        rmtree(tmpdir)
+
+
+parser = argparse.ArgumentParser()
+commands = parser.add_subparsers(title="commands")
+
+install_parser = commands.add_parser("install")
+install_parser.set_defaults(func=install)
+install_parser.add_argument("--quiet", "-q", default=False, action="store_true")
+install_parser.add_argument("--no-replace", default=False, action="store_true")
+
+uninstall_parser = commands.add_parser("uninstall")
+uninstall_parser.set_defaults(func=uninstall)
+upgrade_parser = commands.add_parser("upgrade")
+upgrade_parser.set_defaults(func=upgrade)
+
+args = parser.parse_args()
+
+if len(argv) <= 1:
+    parser.print_help()
+else:
+    args.func()

--- a/setup.py
+++ b/setup.py
@@ -6,9 +6,17 @@ from shutil import copytree
 from shutil import rmtree
 from subprocess import call
 from sys import argv
+from sys import executable
+from subprocess import check_output
+from os import environ
 
 FOLDER_NAME = "cmus-osx/"
 MISSING_DEP_HELP = "Consult the installation section in README."
+
+if environ.get('ENV') is None:
+    REQUIREMENTS_FILE = "requirements.txt"
+elif environ.get('ENV') == "dev":
+    REQUIREMENTS_FILE = "requirements-dev.txt"
 
 CMUS_BASE_DIR = None
 
@@ -29,8 +37,19 @@ RC_ENTRY = "shell %s &\n" % MEDIA_KEYS_PATH
 NOTIFY_PATH = CMUS_BASE_DIR + FOLDER_NAME + "notify.py"
 AUTOSAVE_ENTRY = "set status_display_program=%s" % NOTIFY_PATH
 
+def process_reqs(action):
+    if action == "install":
+        print("Installing requirements...")
+
+        call([executable, '-m', 'pip', 'install', '-r', REQUIREMENTS_FILE])
+    elif action == "uninstall":
+        print("Uninstalling requirements...")
+        call([executable, '-m', 'pip', 'uninstall', '-r', REQUIREMENTS_FILE])
+
 
 def install():
+    process_reqs(argv[1])
+
     if isdir(CMUS_BASE_DIR):
         if isdir(CMUS_BASE_DIR + FOLDER_NAME):
             rmtree(CMUS_BASE_DIR + FOLDER_NAME)
@@ -40,10 +59,12 @@ def install():
             open(RC_PATH, "a").write(RC_ENTRY)
     else:
         open(RC_PATH, "w+").write(RC_ENTRY)
+
     try:
         import mutagen  # noqa: F401
     except ImportError:
         print("mutagen not installed. %s" % MISSING_DEP_HELP)
+
     pyobjc_installed = False
     try:
         import AppKit  # noqa: F401
@@ -56,10 +77,13 @@ def install():
         print("pyobjc not installed. %s" % MISSING_DEP_HELP)
     if pyobjc_installed:
         call([NOTIFY_PATH, "title", "Install successful!"])
-    print("Installed. To enable notifications execute\n%s\nin cmus." % AUTOSAVE_ENTRY)
+
+    print("\nInstalled. To enable notifications execute:\n%s\nin cmus." % AUTOSAVE_ENTRY)
 
 
 def uninstall():
+    process_reqs(argv[1])
+
     if isdir(CMUS_BASE_DIR + FOLDER_NAME):
         rmtree(CMUS_BASE_DIR + FOLDER_NAME)
     if isfile(RC_PATH):


### PR DESCRIPTION
This PR includes some improvements to the `setup.py` script in order to add upgrade option. Requirements are now installed as part of the setup.

I have been using this for a long time but have been frustrated by the lack of upgrade, mainly because I never knew what changed. Because my dotfiles are all symlinked I couldn't just use the `setup.py install` after `git pull`. Instead I am relying on custom scripts.
I think it is easier to upgrade now when new code is available. If needed, migration paths can be catered, since it always uses the `setup.py` in master. It installs the new files without overriding `cmus-osx.config`.

Introduced `argparse` to make it easier to use positional arguments.

To develop locally, just use:
```
ENV=dev ./setup.py install
```

It may not be the best approach to it, but it works 😃
Please let me know your thoughts!