### PR TITLE
Reduce memory footprint for executed scripts

### DIFF
--- a/cmus_osx/constants.py
+++ b/cmus_osx/constants.py
@@ -29,8 +29,8 @@ CMUS_OSX_FOLDER_NAME = "cmus-osx"
 CONFIG_NAME = "cmus-osx.conf"
 
 SCRIPTS: Dict[str, str] = {
-    RC_SCRIPT_NAME: f"#!/bin/sh\n\n{str(INTERPRETER_PATH)} {str(RC_PATH)}",
-    SDP_SCRIPT_NAME: f'#!/bin/sh\n\n{str(INTERPRETER_PATH)} {str(SDP_PATH)} "${{@}}"',
+    RC_SCRIPT_NAME: f"#!/bin/sh\n\nexec {str(INTERPRETER_PATH)} {str(RC_PATH)}",
+    SDP_SCRIPT_NAME: f'#!/bin/sh\n\nexec {str(INTERPRETER_PATH)} {str(SDP_PATH)} "${{@}}"',
 }
 
 COULD_NOT_LOCATED_CMUS_DIRECTORY = 1


### PR DESCRIPTION
Remove lingering shell after starting cmus.
As scripts don't need it, the change doesn't affect functionality, only it uses less resources.

Before
```
--
 \-+- 66015 x1 /bin/sh /Users/x1/.cmus/cmus-osx/rc_entry.sh
   \--- 66016 x1 /Users/x1/.local/share/virtualenvs/cmus-osx-jvlQavCR/bin/python /Users/x1/repo/cmus-osx/cmus_osx/payload/media_keys.py
```

After
```
--
 \--- 66880 x1 /Users/x1/.local/share/virtualenvs/cmus-osx-jvlQavCR/bin/python /Users/x1/repo/cmus-osx/cmus_osx/payload/media_keys.py
```